### PR TITLE
Fixing lint using babel-eslint

### DIFF
--- a/lib/util/eventTime.js
+++ b/lib/util/eventTime.js
@@ -1,78 +1,78 @@
-var dateRegex = new RegExp("^"// ^ make sure there is no prefix
-  + "("                 // [1] Variant A: 1999/12/31
-    + "("
-      + "[0-9]{4}"      // [2] Year: 1999
-    + ")\/("            // [3] Month: (0)1-12
-      + "("
-        + "0?[1-9]"     // [4] (0)1-9
-      + ")|("
-        + "1[0-2]"      // [5] 10-12
-      + ")"
-    + ")\/("            // [6] Date: (0)1-31
-      + "("
-        + "0?[1-9]"     // [7] (0)1-9
-      + ")|("
-        + "[1-2][0-9]"  // [8] 10-29
-      + ")|("
-        + "3[0-1]"      // [9] 30-31
-      + ")"
-    + ")"
-  + ")|("               // [10] Variant B: 31.12.1999
-    + "("               // [11] Date: (0)1-31
-      + "("
-        + "0?[1-9]"     // [12] (0)1-9
-      + ")|("
-        + "[1-2][0-9]"  // [13] 10-29
-      + ")|("
-        + "3[0-1]"      // [14] 30-31
-      + ")"
-    + ")\.("            // [15] Month: (0)1-12
-      + "("
-        + "0?[1-9]"     // [16] (0)1-9
-      + ")|("
-        + "1[0-2]"      // [17] 10-12
-      + ")"
-    + ")\.("
-      + "[0-9]{4}"      // [18] Year: 1999
-    + ")"
-  + ")$")               // $ = make sure there is no postfix
+var dateRegex = new RegExp('^' + // ^ make sure there is no prefix
+  '(' +                // [1] Variant A: 1999/12/31
+    '(' +
+      '[0-9]{4}' +      // [2] Year: 1999
+    ')\/(' +            // [3] Month: (0)1-12
+      '(' +
+        '0?[1-9]' +     // [4] (0)1-9
+      ')|(' +
+        '1[0-2]' +      // [5] 10-12
+      ')' +
+    ')\/(' +            // [6] Date: (0)1-31
+      '(' +
+        '0?[1-9]' +    // [7] (0)1-9
+      ')|(' +
+        '[1-2][0-9]' +  // [8] 10-29
+      ')|(' +
+        '3[0-1]' +      // [9] 30-31
+      ')' +
+    ')' +
+  ')|(' +               // [10] Variant B: 31.12.1999
+    '(' +               // [11] Date: (0)1-31
+      '(' +
+        '0?[1-9]' +     // [12] (0)1-9
+      ')|(' +
+        '[1-2][0-9]' +  // [13] 10-29
+      ')|(' +
+        '3[0-1]' +      // [14] 30-31
+      ')' +
+    ')\.(' +            // [15] Month: (0)1-12
+      '(' +
+        '0?[1-9]' +     // [16] (0)1-9
+      ')|(' +
+        '1[0-2]' +      // [17] 10-12
+      ')' +
+    ')\.(' +
+      '[0-9]{4}' +      // [18] Year: 1999
+    ')' +
+  ')$')               // $ = make sure there is no postfix
 
-var timeRegex = new RegExp("^"// ^ make sure there is no prefix
-    + "("                // [1] Variant A: 29:59
-      + "("
-        + "[0-2]?[0-9]"  // [2] Hour: 00-29 (29:59 is just before 6am next day, useful for late-night events)]
-      + ")\:("
-        + "[0-5][0-9]"   // [3] Minute: 00-59
-      + ")"
-    + ")|("              // [4] Variant B: 12:59am
-      + "("              // [5] Hour: 12
-        + "("
-          + "0?[0-9]"    // [6] 0-9 or 00-09
-        + ")|("
-          + "1[0-2]"     // [7] 10-12
-        + ")"
-      + ")("             // [8] Minute + prefix ":59"
-        + "\:"
-        + "([0-5][0-9])" // [9] Minute: 00-59)
-      + ")?"             // optional: [11] [12]
-      + "("
-        + "("            // [10] am/pm
-          + "(a|p)m"     // [11] a/p
-        + ")|("          // [12] AM/PM
-          + "(A|P)M"     // [13] A/P
-        + ")"
-      + ")"
-    + ")"
-  + "$")                 // $ = make sure there is no postfix
+var timeRegex = new RegExp('^' + // ^ make sure there is no prefix
+    '(' +                // [1] Variant A: 29:59
+      '(' +
+        '[0-2]?[0-9]' +  // [2] Hour: 00-29 (29:59 is just before 6am next day, useful for late-night events)]
+      ')\:(' +
+        '[0-5][0-9]' +   // [3] Minute: 00-59
+      ')' +
+    ')|(' +              // [4] Variant B: 12:59am
+      '(' +              // [5] Hour: 12
+        '(' +
+          '0?[0-9]' +    // [6] 0-9 or 00-09
+        ')|(' +
+          '1[0-2]' +     // [7] 10-12
+        ')' +
+      ')(' +             // [8] Minute + prefix ':59'
+        '\:' +
+        '([0-5][0-9])' + // [9] Minute: 00-59)
+      ')?' +             // optional: [11] [12]
+      '(' +
+        '(' +            // [10] am/pm
+          '(a|p)m' +     // [11] a/p
+        ')|(' +          // [12] AM/PM
+          '(A|P)M' +     // [13] A/P
+        ')' +
+      ')' +
+    ')' +
+  '$')                 // $ = make sure there is no postfix
 
 function fill (str) {
   return str ? (str.length === 0 ? '0' + str : str) : '00'
 }
 
-function parseDateTime (date, time, timeZone) {
-  var dateParts = dateRegex.exec(date)
+function parseDateTime (input, time, timeZone) {
+  var dateParts = dateRegex.exec(input)
   if (!dateParts) {
-    throw new Error('Date can not be parsed. ' + date)
+    throw new Error('Date can not be parsed. ' + input)
   }
   var timeParts = timeRegex.exec(time)
   if (!timeParts) {

--- a/package.json
+++ b/package.json
@@ -28,9 +28,14 @@
     "cli",
     "community"
   ],
+  "standard": {
+    "globals": [ "describe", "it" ],
+    "parser": "babel-eslint"
+  },
   "author": "Martin Heidegger <martin.heidegger@gmail.com>",
   "license": "ISC",
   "devDependencies": {
+    "babel-eslint": "^4.1.6",
     "chai": "^3.4.1",
     "chai-as-promised": "^5.2.0",
     "mocha": "^2.3.4",


### PR DESCRIPTION
@dinodsaurus Seems like the tests you wrote didn't lint due to fat arrow functions. I added babel-eslint to mitigate that and fixed some errors that are now thrown due to the better linter.
