### PR TITLE
Validating for when git version is unsupported

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -19,6 +19,10 @@ Start the script by running `nodeschool-admin` in your terminal.
 
 This tool has **two modes** depending on **the folder** in which it is executed!
 
+# Requirements
+* Minimum [Git](https://git-scm.com/) Version 2.0
+* [Node LTS](https://nodejs.org/en/download/)
+
 # Chapter Mode
  
 To be in `Chapter Mode` you need to move your terminal location to a folder that contains a git repository with a [remote](https://git-scm.com/docs/git-remote) pointing to the repo of your nodeschool chapter.

--- a/lib/index.js
+++ b/lib/index.js
@@ -48,6 +48,8 @@ function getRemote (path) {
             return {repo: repo, remotes: remotes}
           })
         })
+    }, function (err) {
+      log.error('Unsupported git version: ' + err + '\nMinimum git version required 2.0.0\nYou can still use the application, but we cannot asure it will behave correctly')
     })
     .catch(function () {
       return null


### PR DESCRIPTION
Tried on a windows machine with git 1.9.5. 
Added some requirements into the Readme, and a message for the user.

Didn't want to add a `process.exit()` in case git version is `> 2.0`, should it be a blocker?
